### PR TITLE
fix(touchbar): extend search string to exclude false replacements

### DIFF
--- a/.github/scripts/touchbar
+++ b/.github/scripts/touchbar
@@ -102,10 +102,10 @@ esac
 
 echo -e "\nEnter the mode do you want to display by default on the touchbar:"
 get_mode
-sed -i "s/primary_layer.*/primary_layer = \"$mode\"/g" /etc/tiny-dfr.conf
+sed -i "s/primary_layer[ ]*=.*/primary_layer = \"$mode\"/g" /etc/tiny-dfr.conf
 echo -e "\nEnter the mode that you want to be displayed on the touchbar after pressing fn key:"
 get_mode
-sed -i "s/secondary_layer.*/secondary_layer = \"$mode\"/g" /etc/tiny-dfr.conf
+sed -i "s/secondary_layer[ ]*=.*/secondary_layer = \"$mode\"/g" /etc/tiny-dfr.conf
 cat <<EOF
 
 Mode set successfully!


### PR DESCRIPTION
Due to the new sections added to the config now 2 lines could be find by the sed with `primary_layer.*` condition. And because of that the replacement brakes the config file.

So we need to extend the search string to exclude the section.

The same changes should be done for `secondary_layer.*` condition