### PR TITLE
Correct command usage for apple-firmware-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You should be then be able to install and update the following packages with `ap
 - **apple-touchbar**: Driver for touchbar and keyboard backlight on T2 Macs. (DO NOT USE IF INSTALLING `linux-t2`, `linux-t2-lts`, `linux-t2-xanmod` or `linux-t2-xanmod-lts`)
 - **applesmc-t2**: Driver for the System Management Controller on T2 Macs. (DO NOT USE IF INSTALLING `linux-t2`, `linux-t2-lts`, `linux-t2-xanmod` or `linux-t2-xanmod-lts`)
 - **apple-t2-audio-config**: Audio config files for the audio device apple-bce has.
-- **apple-firmware-script**: Debian package for the [script](https://wiki.t2linux.org/tools/firmware.sh) to get Wi-Fi and Bluetooth firmware from macOS. Run using `get-wifi-firmware`.
+- **apple-firmware-script**: Debian package for the [script](https://wiki.t2linux.org/tools/firmware.sh) to get Wi-Fi and Bluetooth firmware from macOS. Run using `get-apple-firmware`.
 - **apfs-dkms**: Debian package for the [linux-apfs-rw](https://github.com/linux-apfs/linux-apfs-rw) driver. (DO NOT USE IF INSTALLING `linux-t2`, `linux-t2-lts`, `linux-t2-xanmod` or `linux-t2-xanmod-lts`)
 - **bcm5974-t2**: Driver for trackpad gestures. (DO NOT USE IF INSTALLING `linux-t2` or `linux-t2-lts`)
 - **linux-t2**: Kernel package for Mainline kernels.


### PR DESCRIPTION
This pull request makes a minor documentation update to the README.md file, clarifying the command used to run the apple-firmware-script package. The script should now be run using get-apple-firmware instead of get-wifi-firmware.